### PR TITLE
#8: Provide PasswordResetAuthenticationDomain (closes #8)

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -8,6 +8,7 @@ align.openParenDefnSite = false
 assumeStandardLibraryStripMargin = true
 includeCurlyBraceInSelectChains = false
 danglingParentheses = true
+trailingCommas = always
 rewrite.rules = [
   AvoidInfix,
   SortImports,

--- a/toctoc/scripts/db-start.sh
+++ b/toctoc/scripts/db-start.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "$DIR"
+
+docker-compose -f ../ci/docker-compose.yml up -d mysql-db postgres-db

--- a/toctoc/scripts/db-stop.sh
+++ b/toctoc/scripts/db-stop.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "$DIR"
+
+docker-compose -f ../ci/docker-compose.yml stop mysql-db postgres-db

--- a/toctoc/slickMySql/src/main/scala/io.buildo.toctoc/slick/authentication/login/MySqlSlickLoginAuthenticationDomain.scala
+++ b/toctoc/slickMySql/src/main/scala/io.buildo.toctoc/slick/authentication/login/MySqlSlickLoginAuthenticationDomain.scala
@@ -18,9 +18,9 @@ import scala.concurrent.Future
 
 class MySqlSlickLoginAuthenticationDomain[F[_]: FutureLift[?[_], Future]](
   db: Database,
-  tableName: String = "login_auth_domain"
+  tableName: String = "login_auth_domain",
 )(
-  implicit F: Sync[F]
+  implicit F: Sync[F],
 ) extends LoginAuthenticationDomain[F]
     with BCryptHashing {
 

--- a/toctoc/slickMySql/src/main/scala/io.buildo.toctoc/slick/authentication/login/MySqlSlickLoginAuthenticationDomain.scala
+++ b/toctoc/slickMySql/src/main/scala/io.buildo.toctoc/slick/authentication/login/MySqlSlickLoginAuthenticationDomain.scala
@@ -16,13 +16,15 @@ import _root_.slick.jdbc.JdbcBackend.Database
 
 import scala.concurrent.Future
 
-class MySqlSlickLoginAuthenticationDomain[F[_]: FutureLift[?[_], Future]](db: Database)(
-  implicit F: Sync[F],
+class MySqlSlickLoginAuthenticationDomain[F[_]: FutureLift[?[_], Future]](
+  db: Database,
+  tableName: String = "login_auth_domain"
+)(
+  implicit F: Sync[F]
 ) extends LoginAuthenticationDomain[F]
     with BCryptHashing {
 
-  class LoginTable(tag: Tag)
-      extends Table[(Int, String, String, String)](tag, "login_auth_domain") {
+  class LoginTable(tag: Tag) extends Table[(Int, String, String, String)](tag, tableName) {
     def id = column[Int]("id", O.PrimaryKey, O.AutoInc)
     def ref = column[String]("ref")
     def username = column[String]("username", O.Length(255))

--- a/toctoc/slickMySql/src/main/scala/io.buildo.toctoc/slick/authentication/token/MySqlSlickAccessTokenAuthenticationDomain.scala
+++ b/toctoc/slickMySql/src/main/scala/io.buildo.toctoc/slick/authentication/token/MySqlSlickAccessTokenAuthenticationDomain.scala
@@ -18,9 +18,9 @@ import java.time.Instant
 
 class MySqlSlickAccessTokenAuthenticationDomain[F[_]: FutureLift[?[_], Future]](
   db: Database,
-  tableName: String = "access_token_auth_domain"
+  tableName: String = "access_token_auth_domain",
 )(
-  implicit F: Sync[F]
+  implicit F: Sync[F],
 ) extends AccessTokenAuthenticationDomain[F] {
 
   class AccessTokenTable(tag: Tag) extends Table[(Int, String, String, Instant)](tag, tableName) {
@@ -37,7 +37,7 @@ class MySqlSlickAccessTokenAuthenticationDomain[F[_]: FutureLift[?[_], Future]](
 
   override def register(
     s: Subject,
-    c: AccessToken
+    c: AccessToken,
   ): F[Either[AuthenticationError, AccessTokenDomain[F]]] =
     F.delay {
       db.run(accessTokenTable += ((0, s.ref, c.value, c.expiresAt)))
@@ -54,14 +54,14 @@ class MySqlSlickAccessTokenAuthenticationDomain[F[_]: FutureLift[?[_], Future]](
     }.futureLift.as(this.asRight)
 
   def authenticate(
-    c: AccessToken
+    c: AccessToken,
   ): F[Either[AuthenticationError, (AccessTokenDomain[F], Subject)]] = {
     F.delay {
       db.run(
         accessTokenTable
           .filter(t => t.token === c.value && t.expiresAt > Instant.now())
           .result
-          .headOption
+          .headOption,
       )
     }.futureLift.map {
       case None =>

--- a/toctoc/slickMySql/src/main/scala/io.buildo.toctoc/slick/authentication/token/MySqlSlickAccessTokenAuthenticationDomain.scala
+++ b/toctoc/slickMySql/src/main/scala/io.buildo.toctoc/slick/authentication/token/MySqlSlickAccessTokenAuthenticationDomain.scala
@@ -16,12 +16,14 @@ import _root_.slick.jdbc.JdbcBackend.Database
 import scala.concurrent.Future
 import java.time.Instant
 
-class MySqlSlickAccessTokenAuthenticationDomain[F[_]: FutureLift[?[_], Future]](db: Database)(
-  implicit F: Sync[F],
+class MySqlSlickAccessTokenAuthenticationDomain[F[_]: FutureLift[?[_], Future]](
+  db: Database,
+  tableName: String = "access_token_auth_domain"
+)(
+  implicit F: Sync[F]
 ) extends AccessTokenAuthenticationDomain[F] {
 
-  class AccessTokenTable(tag: Tag)
-      extends Table[(Int, String, String, Instant)](tag, "access_token_auth_domain") {
+  class AccessTokenTable(tag: Tag) extends Table[(Int, String, String, Instant)](tag, tableName) {
     def id = column[Int]("id", O.PrimaryKey, O.AutoInc)
     def ref = column[String]("ref")
     def token = column[String]("token", O.Length(255))
@@ -35,7 +37,7 @@ class MySqlSlickAccessTokenAuthenticationDomain[F[_]: FutureLift[?[_], Future]](
 
   override def register(
     s: Subject,
-    c: AccessToken,
+    c: AccessToken
   ): F[Either[AuthenticationError, AccessTokenDomain[F]]] =
     F.delay {
       db.run(accessTokenTable += ((0, s.ref, c.value, c.expiresAt)))
@@ -52,14 +54,14 @@ class MySqlSlickAccessTokenAuthenticationDomain[F[_]: FutureLift[?[_], Future]](
     }.futureLift.as(this.asRight)
 
   def authenticate(
-    c: AccessToken,
+    c: AccessToken
   ): F[Either[AuthenticationError, (AccessTokenDomain[F], Subject)]] = {
     F.delay {
       db.run(
         accessTokenTable
           .filter(t => t.token === c.value && t.expiresAt > Instant.now())
           .result
-          .headOption,
+          .headOption
       )
     }.futureLift.map {
       case None =>

--- a/toctoc/slickMySql/src/test/scala/io.buildo.toctoc/slick/authentication/test/MySqlSlickLoginAuthenticationDomainFlowSpec.scala
+++ b/toctoc/slickMySql/src/test/scala/io.buildo.toctoc/slick/authentication/test/MySqlSlickLoginAuthenticationDomainFlowSpec.scala
@@ -5,6 +5,7 @@ package test
 
 import core.authentication.TokenBasedAuthentication._
 import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.concurrent.ScalaFutures
 import _root_.slick.jdbc.MySQLProfile.api._
 import _root_.slick.jdbc.JdbcBackend.Database
@@ -13,7 +14,7 @@ import io.buildo.toctoc.slick.authentication.token.MySqlSlickAccessTokenAuthenti
 import cats.effect.IO
 
 class MySqlSlickLoginAuthenticationDomainFlowSpec
-    extends FlatSpec
+    extends AnyFlatSpec
     with BeforeAndAfterEach
     with BeforeAndAfterAll
     with ScalaFutures

--- a/toctoc/slickPostgreSql/src/main/scala/io.buildo.toctoc/slick/authentication/login/PostgreSqlSlickLoginAuthenticationDomain.scala
+++ b/toctoc/slickPostgreSql/src/main/scala/io.buildo.toctoc/slick/authentication/login/PostgreSqlSlickLoginAuthenticationDomain.scala
@@ -18,9 +18,9 @@ import scala.concurrent.Future
 
 class PostgreSqlSlickLoginAuthenticationDomain[F[_]: FutureLift[?[_], Future]](
   db: Database,
-  tableName: String = "login_auth_domain"
+  tableName: String = "login_auth_domain",
 )(
-  implicit F: Sync[F]
+  implicit F: Sync[F],
 ) extends LoginAuthenticationDomain[F]
     with BCryptHashing {
 
@@ -39,7 +39,7 @@ class PostgreSqlSlickLoginAuthenticationDomain[F[_]: FutureLift[?[_], Future]](
 
   override def register(
     s: Subject,
-    c: Login
+    c: Login,
   ): F[Either[AuthenticationError, LoginDomain[F]]] =
     F.delay {
       db.run(loginTable += ((0, s.ref, c.username, hashPassword(c.password))))
@@ -63,7 +63,7 @@ class PostgreSqlSlickLoginAuthenticationDomain[F[_]: FutureLift[?[_], Future]](
     } yield res).value
 
   override def authenticate(
-    c: Login
+    c: Login,
   ): F[Either[AuthenticationError, (LoginDomain[F], Subject)]] = {
     F.delay {
       db.run(loginTable.filter(_.username === c.username).result)

--- a/toctoc/slickPostgreSql/src/main/scala/io.buildo.toctoc/slick/authentication/token/PostgreSqlSlickAccessTokenAuthenticationDomain.scala
+++ b/toctoc/slickPostgreSql/src/main/scala/io.buildo.toctoc/slick/authentication/token/PostgreSqlSlickAccessTokenAuthenticationDomain.scala
@@ -16,14 +16,17 @@ import _root_.slick.jdbc.JdbcBackend.Database
 import scala.concurrent.Future
 import java.time.Instant
 
-class PostgreSqlSlickAccessTokenAuthenticationDomain[F[_]: FutureLift[?[_], Future]](db: Database)(
-  implicit F: Sync[F],
+class PostgreSqlSlickAccessTokenAuthenticationDomain[F[_]: FutureLift[?[_], Future]](
+  db: Database,
+  tableName: String = "access_token_auth_domain"
+)(
+  implicit F: Sync[F]
 ) extends AccessTokenAuthenticationDomain[F] {
 
   class AccessTokenTable(tag: Tag)
       extends Table[(Int, String, String, Instant)](
         tag,
-        "access_token_auth_domain",
+        tableName
       ) {
     def id = column[Int]("id", O.PrimaryKey, O.AutoInc)
     def ref = column[String]("ref")
@@ -38,7 +41,7 @@ class PostgreSqlSlickAccessTokenAuthenticationDomain[F[_]: FutureLift[?[_], Futu
 
   override def register(
     s: Subject,
-    c: AccessToken,
+    c: AccessToken
   ): F[Either[AuthenticationError, AccessTokenDomain[F]]] = {
     F.delay {
       db.run(accessTokenTable += ((0, s.ref, c.value, c.expiresAt)))
@@ -46,28 +49,28 @@ class PostgreSqlSlickAccessTokenAuthenticationDomain[F[_]: FutureLift[?[_], Futu
   }
 
   override def unregister(
-    s: Subject,
+    s: Subject
   ): F[Either[AuthenticationError, AccessTokenDomain[F]]] =
     F.delay {
       db.run(accessTokenTable.filter(_.ref === s.ref).delete)
     }.futureLift.as(this.asRight)
 
   override def unregister(
-    c: AccessToken,
+    c: AccessToken
   ): F[Either[AuthenticationError, AccessTokenDomain[F]]] =
     F.delay {
       db.run(accessTokenTable.filter(_.token === c.value).delete)
     }.futureLift.as(this.asRight)
 
   override def authenticate(
-    c: AccessToken,
+    c: AccessToken
   ): F[Either[AuthenticationError, (AccessTokenDomain[F], Subject)]] = {
     F.delay {
       db.run(
         accessTokenTable
           .filter(t => t.token === c.value && t.expiresAt > Instant.now())
           .result
-          .headOption,
+          .headOption
       )
     }.futureLift.map {
       case None =>

--- a/toctoc/slickPostgreSql/src/main/scala/io.buildo.toctoc/slick/authentication/token/PostgreSqlSlickAccessTokenAuthenticationDomain.scala
+++ b/toctoc/slickPostgreSql/src/main/scala/io.buildo.toctoc/slick/authentication/token/PostgreSqlSlickAccessTokenAuthenticationDomain.scala
@@ -18,15 +18,15 @@ import java.time.Instant
 
 class PostgreSqlSlickAccessTokenAuthenticationDomain[F[_]: FutureLift[?[_], Future]](
   db: Database,
-  tableName: String = "access_token_auth_domain"
+  tableName: String = "access_token_auth_domain",
 )(
-  implicit F: Sync[F]
+  implicit F: Sync[F],
 ) extends AccessTokenAuthenticationDomain[F] {
 
   class AccessTokenTable(tag: Tag)
       extends Table[(Int, String, String, Instant)](
         tag,
-        tableName
+        tableName,
       ) {
     def id = column[Int]("id", O.PrimaryKey, O.AutoInc)
     def ref = column[String]("ref")
@@ -41,7 +41,7 @@ class PostgreSqlSlickAccessTokenAuthenticationDomain[F[_]: FutureLift[?[_], Futu
 
   override def register(
     s: Subject,
-    c: AccessToken
+    c: AccessToken,
   ): F[Either[AuthenticationError, AccessTokenDomain[F]]] = {
     F.delay {
       db.run(accessTokenTable += ((0, s.ref, c.value, c.expiresAt)))
@@ -49,28 +49,28 @@ class PostgreSqlSlickAccessTokenAuthenticationDomain[F[_]: FutureLift[?[_], Futu
   }
 
   override def unregister(
-    s: Subject
+    s: Subject,
   ): F[Either[AuthenticationError, AccessTokenDomain[F]]] =
     F.delay {
       db.run(accessTokenTable.filter(_.ref === s.ref).delete)
     }.futureLift.as(this.asRight)
 
   override def unregister(
-    c: AccessToken
+    c: AccessToken,
   ): F[Either[AuthenticationError, AccessTokenDomain[F]]] =
     F.delay {
       db.run(accessTokenTable.filter(_.token === c.value).delete)
     }.futureLift.as(this.asRight)
 
   override def authenticate(
-    c: AccessToken
+    c: AccessToken,
   ): F[Either[AuthenticationError, (AccessTokenDomain[F], Subject)]] = {
     F.delay {
       db.run(
         accessTokenTable
           .filter(t => t.token === c.value && t.expiresAt > Instant.now())
           .result
-          .headOption
+          .headOption,
       )
     }.futureLift.map {
       case None =>

--- a/toctoc/slickPostgreSql/src/test/scala/io.buildo.toctoc/slick/authentication/test/PostgreSqlSlickLoginAuthenticationDomainFlowSpec.scala
+++ b/toctoc/slickPostgreSql/src/test/scala/io.buildo.toctoc/slick/authentication/test/PostgreSqlSlickLoginAuthenticationDomainFlowSpec.scala
@@ -8,13 +8,14 @@ import login.PostgreSqlSlickLoginAuthenticationDomain
 import token.PostgreSqlSlickAccessTokenAuthenticationDomain
 
 import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
 import _root_.slick.jdbc.PostgresProfile.api._
 import _root_.slick.jdbc.JdbcBackend.Database
 
 import cats.effect.IO
 
 class PostgreSqlSlickLoginAuthenticationDomainFlowSpec
-    extends FlatSpec
+    extends AnyFlatSpec
     with BeforeAndAfterEach
     with BeforeAndAfterAll
     with EitherValues


### PR DESCRIPTION
Closes #8

- shell scripts for running local postgres and mysql images
- new constructor argument `tableName` to customize table names.

## Test Plan

Existing tests ✅ 

